### PR TITLE
1.16.5 abandon handler

### DIFF
--- a/src/main/scala/com/kotori316/fluidtank/Config.scala
+++ b/src/main/scala/com/kotori316/fluidtank/Config.scala
@@ -25,13 +25,14 @@ object Config {
     builder.comment("Settings for FluidTank.").push("common")
     val removeRecipe: ForgeConfigSpec.BooleanValue = builder.worldRestart().comment("Remove all recipe to make tanks.")
       .define("RemoveRecipe", false)
+    val debug: ForgeConfigSpec.BooleanValue = builder.comment("Debug Mode").define("debug", false)
 
     builder.comment("Recipe settings").push(CATEGORY_RECIPE)
 
-    val easyRecipe: ForgeConfigSpec.BooleanValue = builder.comment("True to use easy recipe.").define("easyRecipe", false)
-    val usableInvisibleInRecipe: ForgeConfigSpec.BooleanValue = builder.comment("False to prohibit invisible tanks to be used in recipes")
+    val easyRecipe: ForgeConfigSpec.BooleanValue = builder.worldRestart().comment("True to use easy recipe.").define("easyRecipe", false)
+    val usableInvisibleInRecipe: ForgeConfigSpec.BooleanValue = builder.worldRestart().comment("False to prohibit invisible tanks to be used in recipes")
       .define("usableInvisibleInRecipe", true)
-    val usableUnavailableTankInRecipe: ForgeConfigSpec.BooleanValue = builder.comment("False to prohibit tanks with no recipe to be used in recipes of other tanks")
+    val usableUnavailableTankInRecipe: ForgeConfigSpec.BooleanValue = builder.worldRestart().comment("False to prohibit tanks with no recipe to be used in recipes of other tanks")
       .define("usableUnavailableTankInRecipe", true)
 
     builder.pop()

--- a/src/main/scala/com/kotori316/fluidtank/ModObjects.scala
+++ b/src/main/scala/com/kotori316/fluidtank/ModObjects.scala
@@ -90,4 +90,5 @@ object ModObjects {
   final val MARKER_PipeTileBase = MarkerManager.getMarker("PipeTileBase")
   final val MARKER_TankHandler = MarkerManager.getMarker("TankHandler")
   final val MARKER_ListTankHandler = MarkerManager.getMarker("ListTankHandler")
+  final val MARKER_DebugFluidHandler = MarkerManager.getMarker("DebugFluidHandler")
 }

--- a/src/main/scala/com/kotori316/fluidtank/Utils.java
+++ b/src/main/scala/com/kotori316/fluidtank/Utils.java
@@ -26,8 +26,15 @@ public class Utils {
         return OptionConverters.toJava(option);
     }
 
+    private static final AtomicInteger inDev = new AtomicInteger(-1);
+
     public static boolean isInDev() {
-        return !FMLLoader.isProduction();
+        int i = inDev.get();
+        if (i == -1) {
+            inDev.set(!FMLLoader.isProduction() || Config.content().debug().get() ? 1 : 0);
+            return inDev.get() == 1;
+        }
+        return i == 1;
     }
 
     @SuppressWarnings({"unused", "SpellCheckingInspection"})

--- a/src/main/scala/com/kotori316/fluidtank/fluids/DebugFluidHandler.scala
+++ b/src/main/scala/com/kotori316/fluidtank/fluids/DebugFluidHandler.scala
@@ -1,25 +1,25 @@
 package com.kotori316.fluidtank.fluids
 
-import com.kotori316.fluidtank.ModObjects
-import com.kotori316.fluidtank.fluids.DebugFluidHandler.{LOGGER, MARKER}
+import com.kotori316.fluidtank.fluids.DebugFluidHandler.{LOGGER, LOG_LEVEL, MARKER}
+import com.kotori316.fluidtank.{ModObjects, Utils}
 import net.minecraftforge.fluids.FluidStack
 import net.minecraftforge.fluids.capability.IFluidHandler
 import net.minecraftforge.fluids.capability.templates.EmptyFluidHandler
-import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.{Level, LogManager}
 
 class DebugFluidHandler private() extends EmptyFluidHandler {
   override def fill(resource: FluidStack, action: IFluidHandler.FluidAction): Int = {
-    LOGGER.info(MARKER, "Fill {}, mode {}", resource: AnyRef, action: AnyRef)
+    LOGGER.log(LOG_LEVEL, MARKER, "Fill {}, mode {}", resource: AnyRef, action: AnyRef)
     super.fill(resource, action)
   }
 
   override def drain(resource: FluidStack, action: IFluidHandler.FluidAction): FluidStack = {
-    LOGGER.info(MARKER, "Drain {}, mode {}", resource: AnyRef, action: AnyRef)
+    LOGGER.log(LOG_LEVEL, MARKER, "Drain {}, mode {}", resource: AnyRef, action: AnyRef)
     super.drain(resource, action)
   }
 
   override def drain(maxDrain: Int, action: IFluidHandler.FluidAction): FluidStack = {
-    LOGGER.info(MARKER, "Drain amount {}, mode {}", maxDrain: Any, action: AnyRef)
+    LOGGER.log(LOG_LEVEL, MARKER, "Drain amount {}, mode {}", maxDrain: Any, action: AnyRef)
     super.drain(maxDrain, action)
   }
 
@@ -30,4 +30,5 @@ object DebugFluidHandler {
   final val INSTANCE = new DebugFluidHandler
   private final val LOGGER = LogManager.getLogger(classOf[DebugFluidHandler])
   private final val MARKER = ModObjects.MARKER_DebugFluidHandler
+  private final val LOG_LEVEL = if (Utils.isInDev) Level.INFO else Level.DEBUG
 }

--- a/src/main/scala/com/kotori316/fluidtank/fluids/DebugFluidHandler.scala
+++ b/src/main/scala/com/kotori316/fluidtank/fluids/DebugFluidHandler.scala
@@ -1,0 +1,33 @@
+package com.kotori316.fluidtank.fluids
+
+import com.kotori316.fluidtank.ModObjects
+import com.kotori316.fluidtank.fluids.DebugFluidHandler.{LOGGER, MARKER}
+import net.minecraftforge.fluids.FluidStack
+import net.minecraftforge.fluids.capability.IFluidHandler
+import net.minecraftforge.fluids.capability.templates.EmptyFluidHandler
+import org.apache.logging.log4j.LogManager
+
+class DebugFluidHandler private() extends EmptyFluidHandler {
+  override def fill(resource: FluidStack, action: IFluidHandler.FluidAction): Int = {
+    LOGGER.info(MARKER, "Fill {}, mode {}", resource: AnyRef, action: AnyRef)
+    super.fill(resource, action)
+  }
+
+  override def drain(resource: FluidStack, action: IFluidHandler.FluidAction): FluidStack = {
+    LOGGER.info(MARKER, "Drain {}, mode {}", resource: AnyRef, action: AnyRef)
+    super.drain(resource, action)
+  }
+
+  override def drain(maxDrain: Int, action: IFluidHandler.FluidAction): FluidStack = {
+    LOGGER.info(MARKER, "Drain amount {}, mode {}", maxDrain: Any, action: AnyRef)
+    super.drain(maxDrain, action)
+  }
+
+  override def toString: String = "DebugFluidHandler@FluidTank"
+}
+
+object DebugFluidHandler {
+  final val INSTANCE = new DebugFluidHandler
+  private final val LOGGER = LogManager.getLogger(classOf[DebugFluidHandler])
+  private final val MARKER = ModObjects.MARKER_DebugFluidHandler
+}

--- a/src/main/scala/com/kotori316/fluidtank/tiles/Connection.scala
+++ b/src/main/scala/com/kotori316/fluidtank/tiles/Connection.scala
@@ -3,7 +3,7 @@ package com.kotori316.fluidtank.tiles
 import cats.data._
 import cats.implicits._
 import com.kotori316.fluidtank._
-import com.kotori316.fluidtank.fluids.{FluidAmount, FluidTransferLog, ListTankHandler, TankHandler, fillAll}
+import com.kotori316.fluidtank.fluids.{DebugFluidHandler, FluidAmount, FluidTransferLog, ListTankHandler, TankHandler, fillAll}
 import net.minecraft.util.Direction
 import net.minecraft.util.math.{BlockPos, MathHelper}
 import net.minecraft.util.text.{ITextComponent, StringTextComponent, TranslationTextComponent}
@@ -86,7 +86,8 @@ sealed class Connection(s: Seq[TileTankNoDisplay]) extends ICapabilityProvider {
   }
 
   // ----- START DEPRECATED REMOVE IN 1.17 -----
-  private[this] final val lazyOptional = LazyOptional.of(() => if (seq.nonEmpty) handler else EmptyFluidHandler.INSTANCE)
+  private[this] final val lazyOptional = LazyOptional.of(() => if (seq.nonEmpty) handler
+  else if (Utils.isInDev) DebugFluidHandler.INSTANCE else EmptyFluidHandler.INSTANCE)
 
   private[tiles] def isValid = mIsValid
 

--- a/src/main/scala/com/kotori316/fluidtank/tiles/TileTankNoDisplay.scala
+++ b/src/main/scala/com/kotori316/fluidtank/tiles/TileTankNoDisplay.scala
@@ -8,11 +8,14 @@ import net.minecraft.block.BlockState
 import net.minecraft.nbt.CompoundNBT
 import net.minecraft.network.NetworkManager
 import net.minecraft.network.play.server.SUpdateTileEntityPacket
-import net.minecraft.tileentity.{ITickableTileEntity, TileEntity, TileEntityType}
+import net.minecraft.server.MinecraftServer
+import net.minecraft.tileentity.{TileEntity, TileEntityType}
+import net.minecraft.util.concurrent.TickDelayedTask
 import net.minecraft.util.text.{ITextComponent, StringTextComponent}
 import net.minecraft.util.{Direction, INameable}
 import net.minecraftforge.common.capabilities.Capability
 import net.minecraftforge.common.util.LazyOptional
+import net.minecraftforge.fml.{LogicalSide, LogicalSidedProvider}
 
 import scala.collection.mutable.ArrayBuffer
 //import net.minecraftforge.fml.common.Optional
@@ -22,7 +25,6 @@ import scala.collection.mutable.ArrayBuffer
 class TileTankNoDisplay(var tier: Tiers, t: TileEntityType[_ <: TileTankNoDisplay])
   extends TileEntity(t)
     with INameable
-    with ITickableTileEntity
     /*with ICustomPipeConnection
     with IDebuggable*/ {
   self =>
@@ -86,6 +88,21 @@ class TileTankNoDisplay(var tier: Tiers, t: TileEntityType[_ <: TileTankNoDispla
   }
 
   override def onDataPacket(net: NetworkManager, pkt: SUpdateTileEntityPacket): Unit = () //handleUpdateTag(pkt.getNbtCompound) // No way to get state
+  override def onLoad(): Unit = {
+    super.onLoad()
+    if (loading) {
+      loading = false
+      if (SideProxy.isServer(this)) {
+        val executor: MinecraftServer = LogicalSidedProvider.WORKQUEUE.get(LogicalSide.SERVER)
+        executor.enqueue(new TickDelayedTask(executor.getTickCounter, () => {
+          getWorld.getProfiler.startSection("Connection Loading")
+          if (this.connection.isDummy)
+            Connection.load(getWorld, getPos)
+          getWorld.getProfiler.endSection()
+        }))
+      }
+    }
+  }
 
   override def getCapability[T](capability: Capability[T], facing: Direction): LazyOptional[T] = {
     val c = connection.getCapability(capability, facing)
@@ -150,17 +167,6 @@ class TileTankNoDisplay(var tier: Tiers, t: TileEntityType[_ <: TileTankNoDispla
     left.add("Tier : " + tier)
     left add tank.toString
   }*/
-  override def tick(): Unit = {
-    if (loading) {
-      loading = false
-      if (SideProxy.isServer(this)) {
-        getWorld.getProfiler.startSection("Connection Loading")
-        if (this.connection.isDummy)
-          Connection.load(getWorld, getPos)
-        getWorld.getProfiler.endSection()
-      }
-    }
-  }
 }
 
 object TileTankNoDisplay {

--- a/src/main/scala/com/kotori316/fluidtank/tiles/TileTankNoDisplay.scala
+++ b/src/main/scala/com/kotori316/fluidtank/tiles/TileTankNoDisplay.scala
@@ -155,7 +155,7 @@ class TileTankNoDisplay(var tier: Tiers, t: TileEntityType[_ <: TileTankNoDispla
       loading = false
       if (SideProxy.isServer(this)) {
         getWorld.getProfiler.startSection("Connection Loading")
-        if (this.connection == Connection.invalid)
+        if (this.connection.isDummy)
           Connection.load(getWorld, getPos)
         getWorld.getProfiler.endSection()
       }


### PR DESCRIPTION
Close #72 
* Fixed the tank hander was not made to be invalid.
* Create Dummy handler to log fluid transfer via invalid LazyOptional
* Do initialization in onLoad block and remove tickable usage.