### PR TITLE
1.16.5 condition

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 1.8, 11 ]
+        java: [ 8, 11 ]
     name: Build Check for Java ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2

--- a/src/main/resources/assets/fluidtank/blockstates/tank_wood.json
+++ b/src/main/resources/assets/fluidtank/blockstates/tank_wood.json
@@ -1,5 +1,8 @@
 {
   "variants": {
-    "": {"model": "fluidtank:block/tank_wood"}
+    "tank_pos=single": {"model": "fluidtank:block/tank_wood"},
+    "tank_pos=top": {"model": "fluidtank:block/tank_wood"},
+    "tank_pos=bottom": {"model": "fluidtank:block/tank_wood"},
+    "tank_pos=middle": {"model": "fluidtank:block/tank_wood"}
   }
 }

--- a/src/main/scala/com/kotori316/fluidtank/blocks/BlockTank.scala
+++ b/src/main/scala/com/kotori316/fluidtank/blocks/BlockTank.scala
@@ -7,6 +7,7 @@ import net.minecraft.block.{AbstractBlock, Block, BlockState}
 import net.minecraft.entity.LivingEntity
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.item.{Item, ItemStack}
+import net.minecraft.state.StateContainer
 import net.minecraft.tileentity.TileEntity
 import net.minecraft.util.math.shapes.{ISelectionContext, VoxelShape}
 import net.minecraft.util.math.{BlockPos, BlockRayTraceResult, RayTraceResult}
@@ -23,6 +24,7 @@ class BlockTank(val tier: Tiers) extends Block(AbstractBlock.Properties.create(M
   Creative Tank -> "fluidtank:creative"
    */
   setRegistryName(FluidTank.modID, namePrefix + tier.toString.toLowerCase)
+  setDefaultState(this.stateContainer.getBaseState.`with`(TankPos.TANK_POS_PROPERTY, TankPos.SINGLE))
   val itemBlock = new ItemBlockTank(this)
 
   override final def asItem(): Item = itemBlock
@@ -114,4 +116,8 @@ class BlockTank(val tier: Tiers) extends Block(AbstractBlock.Properties.create(M
   //noinspection ScalaDeprecation
   override def getShape(state: BlockState, worldIn: IBlockReader, pos: BlockPos, context: ISelectionContext): VoxelShape = ModObjects.TANK_SHAPE
 
+  override def fillStateContainer(builder: StateContainer.Builder[Block, BlockState]): Unit = {
+    super.fillStateContainer(builder)
+    builder.add(TankPos.TANK_POS_PROPERTY)
+  }
 }

--- a/src/main/scala/com/kotori316/fluidtank/blocks/TankPos.java
+++ b/src/main/scala/com/kotori316/fluidtank/blocks/TankPos.java
@@ -1,0 +1,22 @@
+package com.kotori316.fluidtank.blocks;
+
+import java.util.Locale;
+
+import net.minecraft.state.EnumProperty;
+import net.minecraft.util.IStringSerializable;
+
+public enum TankPos implements IStringSerializable {
+    TOP, MIDDLE, BOTTOM, SINGLE;
+
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+
+    @Override
+    public String getString() {
+        return toString();
+    }
+
+    public static final EnumProperty<TankPos> TANK_POS_PROPERTY = EnumProperty.create("tank_pos", TankPos.class);
+}

--- a/src/main/scala/com/kotori316/fluidtank/tiles/Connection.scala
+++ b/src/main/scala/com/kotori316/fluidtank/tiles/Connection.scala
@@ -152,7 +152,7 @@ object Connection {
         val last = seq.last
         last.getWorld.setBlockState(last.getPos, last.getBlockState.`with`(TankPos.TANK_POS_PROPERTY, TankPos.TOP))
         // MIDDLE
-        seq.tail.dropRight(1).foreach(t => t.getWorld.setBlockState(t.getPos, t.getBlockState.`with`(TankPos.TANK_POS_PROPERTY, TankPos.MIDDLE)))
+        seq.tail.init.foreach(t => t.getWorld.setBlockState(t.getPos, t.getBlockState.`with`(TankPos.TANK_POS_PROPERTY, TankPos.MIDDLE)))
       } else {
         // SINGLE
         seq.foreach(t => t.getWorld.setBlockState(t.getPos, t.getBlockState.`with`(TankPos.TANK_POS_PROPERTY, TankPos.SINGLE)))

--- a/src/main/scala/com/kotori316/fluidtank/tiles/Connection.scala
+++ b/src/main/scala/com/kotori316/fluidtank/tiles/Connection.scala
@@ -3,6 +3,7 @@ package com.kotori316.fluidtank.tiles
 import cats.data._
 import cats.implicits._
 import com.kotori316.fluidtank._
+import com.kotori316.fluidtank.blocks.TankPos
 import com.kotori316.fluidtank.fluids.{DebugFluidHandler, FluidAmount, FluidTransferLog, ListTankHandler, TankHandler, fillAll}
 import net.minecraft.util.Direction
 import net.minecraft.util.math.{BlockPos, MathHelper}
@@ -17,8 +18,7 @@ import net.minecraftforge.fluids.capability.{CapabilityFluidHandler, IFluidHandl
 
 import scala.collection.mutable.ArrayBuffer
 
-sealed class Connection(s: Seq[TileTankNoDisplay]) extends ICapabilityProvider {
-  val seq: Seq[TileTankNoDisplay] = s.sortBy(_.getPos.getY)
+sealed class Connection private(val seq: Seq[TileTankNoDisplay]) extends ICapabilityProvider {
   val hasCreative: Boolean = seq.exists(_.isInstanceOf[TileTankCreative])
   val hasVoid: Boolean = seq.exists(_.isInstanceOf[TileTankVoid])
   val updateActions: ArrayBuffer[() => Unit] = ArrayBuffer(
@@ -29,7 +29,7 @@ sealed class Connection(s: Seq[TileTankNoDisplay]) extends ICapabilityProvider {
   val isDummy: Boolean = false
   private[tiles] final var mIsValid = true
 
-  val capabilities: Cap[CapabilityDispatcher] = if (s.nonEmpty) {
+  val capabilities: Cap[CapabilityDispatcher] = if (seq.nonEmpty) {
     val event = new AttachCapabilitiesEvent[Connection](classOf[Connection], this)
     MinecraftForge.EVENT_BUS.post(event)
     if (event.getCapabilities.isEmpty) {
@@ -139,13 +139,32 @@ sealed class Connection(s: Seq[TileTankNoDisplay]) extends ICapabilityProvider {
 object Connection {
 
   def create(s: Seq[TileTankNoDisplay]): Connection = {
-    if (s.isEmpty) invalid
-    else new Connection(s)
+    if (s.isEmpty) {
+      invalid
+    } else {
+      val seq = s.sortBy(_.getPos.getY)
+      // Property update
+      if (seq.lengthIs > 1) {
+        // HEAD
+        val head = seq.head
+        head.getWorld.setBlockState(head.getPos, head.getBlockState.`with`(TankPos.TANK_POS_PROPERTY, TankPos.BOTTOM))
+        // LAST
+        val last = seq.last
+        last.getWorld.setBlockState(last.getPos, last.getBlockState.`with`(TankPos.TANK_POS_PROPERTY, TankPos.TOP))
+        // MIDDLE
+        seq.tail.dropRight(1).foreach(t => t.getWorld.setBlockState(t.getPos, t.getBlockState.`with`(TankPos.TANK_POS_PROPERTY, TankPos.MIDDLE)))
+      } else {
+        // SINGLE
+        seq.foreach(t => t.getWorld.setBlockState(t.getPos, t.getBlockState.`with`(TankPos.TANK_POS_PROPERTY, TankPos.SINGLE)))
+      }
+      new Connection(seq)
+    }
   }
 
   @scala.annotation.tailrec
-  def createAndInit(s: Seq[TileTankNoDisplay]): Unit = {
-    if (s.nonEmpty) {
+  def createAndInit(tankSeq: Seq[TileTankNoDisplay]): Unit = {
+    if (tankSeq.nonEmpty) {
+      val s = tankSeq.sortBy(_.getPos.getY)
       val fluid = s.map(_.internalTank.getFluid).find(_.nonEmpty).getOrElse(FluidAmount.EMPTY)
       val (s1, s2) = s.span(t => t.internalTank.getFluid.fluidEqual(fluid) || t.internalTank.getFluid.isEmpty)
       // Assert tanks in s1 have the same fluid.


### PR DESCRIPTION
Added new property, "tank_pos", to block of tank.
This property shows the current position of tank in these 4 values,
* single
* bottom
* middle
* top

This property is read-only. Any modification of this property will be ignored. In server side, there are no code that reads this property, meaning this will affect only the visual of the block. The property will be updated when the connection of tank updated (place new tank or just load the world).

Close #79 

[Here](https://github.com/Kotori316/FluidTank/blob/c9acb1abdfc92efd9b7ff37c4c91adb33ee938db/src/main/resources/assets/fluidtank/blockstates/tank_wood.json) is an example of model loading. Override this file and set your own model file to change the model for each tank position.