### PR TITLE
1.18 config2

### DIFF
--- a/src/main/scala/com/kotori316/fluidtank/Config.scala
+++ b/src/main/scala/com/kotori316/fluidtank/Config.scala
@@ -1,36 +1,14 @@
 package com.kotori316.fluidtank
 
-import java.lang.{Double => JDouble}
-import java.util.function.Supplier
-
 import net.minecraftforge.common.ForgeConfigSpec
-
-import scala.jdk.javaapi.CollectionConverters
 
 object Config {
   final val CATEGORY_RECIPE = "recipe"
-  final val defaultConfig: Map[String, AnyVal] = Map(
-    "removeRecipe" -> false,
-    "debug" -> false,
-    "easyRecipe" -> false,
-    "usableInvisibleInRecipe" -> true,
-    "usableUnavailableTankInRecipe" -> true,
-    "showInvisibleTank" -> true,
-    "showTOP" -> true,
-    "enableWailaAndTOP" -> true,
-    "enableFluidSupplier" -> false,
-    "enablePipeRainbowRenderer" -> false,
-    "pipeColor" -> (0xF0000000 + 0xFFFFFF),
-    "renderLowerBound" -> 0.001d,
-    "renderUpperBound" -> (1 - 0.001d),
-  )
-  private var mContent: IContent = _
-  var dummyContent: IContent = Utils.TestConfig.getTestInstance(CollectionConverters.asJava(defaultConfig))
+  private var mContent: Content = _
 
-  def content: IContent = if (mContent == null) dummyContent else mContent
+  def content: Content = mContent
 
-  def sync(): ForgeConfigSpec = {
-    val builder = new ForgeConfigSpec.Builder
+  def sync(builder: ForgeConfigSpec.Builder): ForgeConfigSpec = {
     mContent = new Content(builder)
     val spec = builder.build()
     spec
@@ -41,77 +19,49 @@ object Config {
       sync()
     }
   }*/
-  trait BoolSupplier extends java.util.function.BooleanSupplier {
-    def get(): Boolean
 
-    override def getAsBoolean: Boolean = get()
-  }
-
-
-  class Content(builder: ForgeConfigSpec.Builder) extends IContent {
-    private def asSupplier(b: ForgeConfigSpec.BooleanValue): BoolSupplier = () => b.get()
-
-    private def asSupplier[T](b: ForgeConfigSpec.ConfigValue[T]): java.util.function.Supplier[T] = () => b.get()
-
+  class Content(builder: ForgeConfigSpec.Builder) {
     builder.comment("Settings for FluidTank.").push("common")
-    val removeRecipe: BoolSupplier = asSupplier(builder.worldRestart().comment("Remove all recipe to make tanks.")
-      .define("RemoveRecipe", false))
-    val debug: BoolSupplier = asSupplier(builder.comment("Debug Mode").define("debug", false))
+    val removeRecipe: ForgeConfigSpec.BooleanValue = builder.worldRestart().comment("Remove all recipe to make tanks.")
+      .define("RemoveRecipe", false)
+    val debug: ForgeConfigSpec.BooleanValue = builder.comment("Debug Mode").define("debug", false)
 
     builder.comment("Recipe settings").push(CATEGORY_RECIPE)
 
-    val easyRecipe: BoolSupplier = asSupplier(builder.worldRestart().comment("True to use easy recipe.")
-      .define("easyRecipe", false))
-    val usableUnavailableTankInRecipe: BoolSupplier = asSupplier(builder.worldRestart()
+    val easyRecipe: ForgeConfigSpec.BooleanValue = builder.worldRestart().comment("True to use easy recipe.")
+      .define("easyRecipe", false)
+    val usableUnavailableTankInRecipe: ForgeConfigSpec.BooleanValue = builder.worldRestart()
       .comment("False to prohibit tanks with no recipe from being used in recipes of other tanks.")
-      .define("usableUnavailableTankInRecipe", true))
+      .define("usableUnavailableTankInRecipe", true)
 
     builder.pop()
 
-    val showInvisibleTank: BoolSupplier = asSupplier(builder.worldRestart()
+    val showInvisibleTank: ForgeConfigSpec.BooleanValue = builder.worldRestart()
       .comment("True to show invisible tank in creative tabs. Recipe and block aren't removed.")
-      .define("showInvisibleTankInTab", false))
+      .define("showInvisibleTankInTab", false)
 
-    val showTOP: BoolSupplier = asSupplier(builder.comment("Show tank info on TOP tooltip.")
-      .define("showTOP", true))
+    val showTOP: ForgeConfigSpec.BooleanValue = builder.comment("Show tank info on TOP tooltip.")
+      .define("showTOP", true)
 
-    val enableWailaAndTOP: BoolSupplier = asSupplier(builder.comment("True to enable waila and top to show tank info.")
-      .define("showToolTipOnMods", true))
+    val enableWailaAndTOP: ForgeConfigSpec.BooleanValue = builder.comment("True to enable waila and top to show tank info.")
+      .define("showToolTipOnMods", true)
 
-    val enableFluidSupplier: BoolSupplier = asSupplier(builder.comment("True to allow fluid supplier to work.")
-      .define("enableFluidSupplier", false))
+    val enableFluidSupplier: ForgeConfigSpec.BooleanValue = builder.comment("True to allow fluid supplier to work.")
+      .define("enableFluidSupplier", false)
 
-    val enablePipeRainbowRenderer: BoolSupplier = asSupplier(builder.worldRestart()
-      .comment("False to disable rainbow renderer for pipe.").define("enablePipeRainbowRenderer", false))
-    val pipeColor: Supplier[Integer] = asSupplier(builder.worldRestart()
+    val enablePipeRainbowRenderer: ForgeConfigSpec.BooleanValue = builder.worldRestart()
+      .comment("False to disable rainbow renderer for pipe.").define("enablePipeRainbowRenderer", false)
+    val pipeColor: ForgeConfigSpec.ConfigValue[Integer] = builder.worldRestart()
       .comment("Default color of pipe. Works only if \'enablePipeRainbowRenderer\' is false.")
-      .define("pipeColor", Int.box(0xF0000000 + 0xFFFFFF)))
-    val renderLowerBound: Supplier[JDouble] = asSupplier(builder.worldRestart()
+      .define("pipeColor", Int.box(0xF0000000 + 0xFFFFFF))
+    val renderLowerBound: ForgeConfigSpec.DoubleValue = builder.worldRestart()
       .comment("The lower bound of position of fluid rendering. Default 0.001")
-      .defineInRange("renderLowerBound", 0.001d, 0d, 1d))
-    val renderUpperBound: Supplier[JDouble] = asSupplier(builder.worldRestart()
+      .defineInRange("renderLowerBound", 0.001d, 0d, 1d)
+    val renderUpperBound: ForgeConfigSpec.DoubleValue = builder.worldRestart()
       .comment("The upper bound of position of fluid rendering. Default 0.999")
-      .defineInRange("renderUpperBound", 1d - 0.001d, 0d, 1d))
+      .defineInRange("renderUpperBound", 1d - 0.001d, 0d, 1d)
     builder.pop()
 
   }
 
-}
-
-trait IContent {
-
-  import com.kotori316.fluidtank.Config.BoolSupplier
-
-  val removeRecipe: BoolSupplier
-  val debug: BoolSupplier
-  val easyRecipe: BoolSupplier
-  val usableUnavailableTankInRecipe: BoolSupplier
-  val showInvisibleTank: BoolSupplier
-  val showTOP: BoolSupplier
-  val enableWailaAndTOP: BoolSupplier
-  val enableFluidSupplier: BoolSupplier
-  val enablePipeRainbowRenderer: BoolSupplier
-  val pipeColor: Supplier[Integer]
-  val renderLowerBound: Supplier[JDouble]
-  val renderUpperBound: Supplier[JDouble]
 }

--- a/src/main/scala/com/kotori316/fluidtank/FluidTank.java
+++ b/src/main/scala/com/kotori316/fluidtank/FluidTank.java
@@ -6,6 +6,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.event.RegistryEvent;
@@ -39,7 +40,7 @@ public class FluidTank {
     public static final SideProxy proxy = SideProxy.get();
 
     public FluidTank() {
-        ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Config.sync());
+        ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Config.sync(new ForgeConfigSpec.Builder()));
         ForgeMod.enableMilkFluid();
         FMLJavaModLoadingContext.get().getModEventBus().register(Register.class);
         FMLJavaModLoadingContext.get().getModEventBus().register(proxy);

--- a/src/main/scala/com/kotori316/fluidtank/Utils.java
+++ b/src/main/scala/com/kotori316/fluidtank/Utils.java
@@ -7,7 +7,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import net.minecraft.core.Holder;
@@ -146,94 +145,5 @@ public class Utils {
             .flatMap(HolderSet.Named::stream)
             .map(Holder::value)
             .collect(Collectors.toSet());
-    }
-
-    @SuppressWarnings("ClassCanBeRecord")
-    public static class TestConfig implements IContent {
-        private final Map<String, Object> configs;
-
-        public static IContent getTestInstance(Map<String, Object> configs) {
-            return new TestConfig(configs);
-        }
-
-        private TestConfig(Map<String, Object> configs) {
-            this.configs = configs;
-        }
-
-        private Config.BoolSupplier createBool() {
-            String methodName = Thread.currentThread().getStackTrace()[2].getMethodName();
-            return new Config.BoolSupplier() {
-                @Override
-                public boolean get() {
-                    return ((boolean) configs.getOrDefault(methodName, false));
-                }
-            };
-        }
-
-        @SuppressWarnings("unchecked")
-        private <T> Supplier<T> createGeneric() {
-            String methodName = Thread.currentThread().getStackTrace()[2].getMethodName();
-            return () -> ((T) configs.getOrDefault(methodName, 0));
-        }
-
-        @Override
-        public Config.BoolSupplier removeRecipe() {
-            return createBool();
-        }
-
-        @Override
-        public Config.BoolSupplier debug() {
-            return createBool();
-        }
-
-        @Override
-        public Config.BoolSupplier easyRecipe() {
-            return createBool();
-        }
-
-        @Override
-        public Config.BoolSupplier usableUnavailableTankInRecipe() {
-            return createBool();
-        }
-
-        @Override
-        public Config.BoolSupplier showInvisibleTank() {
-            return createBool();
-        }
-
-        @Override
-        public Config.BoolSupplier showTOP() {
-            return createBool();
-        }
-
-        @Override
-        public Config.BoolSupplier enableWailaAndTOP() {
-            return createBool();
-        }
-
-        @Override
-        public Config.BoolSupplier enableFluidSupplier() {
-            return createBool();
-        }
-
-        @Override
-        public Config.BoolSupplier enablePipeRainbowRenderer() {
-            return createBool();
-        }
-
-        @Override
-        public Supplier<Integer> pipeColor() {
-            return createGeneric();
-        }
-
-        @Override
-        public Supplier<Double> renderLowerBound() {
-            return createGeneric();
-        }
-
-        @Override
-        public Supplier<Double> renderUpperBound() {
-            return createGeneric();
-        }
     }
 }

--- a/src/main/scala/com/kotori316/fluidtank/integration/jade/TankWailaPlugin.java
+++ b/src/main/scala/com/kotori316/fluidtank/integration/jade/TankWailaPlugin.java
@@ -8,6 +8,7 @@ import mcp.mobius.waila.api.WailaPlugin;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
+import com.kotori316.fluidtank.Config;
 import com.kotori316.fluidtank.FluidTank;
 import com.kotori316.fluidtank.blocks.BlockTank;
 import com.kotori316.fluidtank.tiles.TileTank;
@@ -39,16 +40,20 @@ public class TankWailaPlugin implements IWailaPlugin {
     @Override
     @SuppressWarnings("UnstableApiUsage")
     public void register(IWailaCommonRegistration registrar) {
-        TankDataProvider tankDataProvider = new TankDataProvider();
-        registrar.registerBlockDataProvider(tankDataProvider, BlockEntity.class);
-        registrar.addConfig(KEY_TANK_INFO, true);
-        registrar.addConfig(KEY_SHORT_INFO, true);
+        if (Config.content().enableWailaAndTOP().get()) {
+            TankDataProvider tankDataProvider = new TankDataProvider();
+            registrar.registerBlockDataProvider(tankDataProvider, BlockEntity.class);
+            registrar.addConfig(KEY_TANK_INFO, true);
+            registrar.addConfig(KEY_SHORT_INFO, true);
+        }
     }
 
     @Override
     @SuppressWarnings("UnstableApiUsage")
     public void registerClient(IWailaClientRegistration registrar) {
-        TankDataProvider tankDataProvider = new TankDataProvider();
-        registrar.registerComponentProvider(tankDataProvider, TooltipPosition.BODY, BlockTank.class);
+        if (Config.content().enableWailaAndTOP().get()) {
+            TankDataProvider tankDataProvider = new TankDataProvider();
+            registrar.registerComponentProvider(tankDataProvider, TooltipPosition.BODY, BlockTank.class);
+        }
     }
 }

--- a/src/main/scala/com/kotori316/fluidtank/integration/top/FluidTankTOPPlugin.scala
+++ b/src/main/scala/com/kotori316/fluidtank/integration/top/FluidTankTOPPlugin.scala
@@ -1,6 +1,7 @@
 package com.kotori316.fluidtank.integration.top
 
 import cats.data.{Kleisli, Reader}
+import com.kotori316.fluidtank.Config
 import mcjty.theoneprobe.api.ITheOneProbe
 import net.minecraftforge.fml.{InterModComms, ModList}
 
@@ -9,7 +10,7 @@ object FluidTankTOPPlugin {
 
   private class Function extends java.util.function.Function[ITheOneProbe, Void] {
     override def apply(t: ITheOneProbe): Void = {
-      t.registerProvider(new TankDataProvider)
+      if (Config.content.enableWailaAndTOP.get()) t.registerProvider(new TankDataProvider)
       null
     }
   }

--- a/src/test/scala/com/kotori316/fluidtank/AccessTest.java
+++ b/src/test/scala/com/kotori316/fluidtank/AccessTest.java
@@ -50,8 +50,8 @@ final class AccessTest extends BeforeAllTest {
 
     @Test
     void configAccess() {
-        assertTrue(Config.content().debug());
-        assertFalse(Config.content().removeRecipe());
+        assertTrue(Config.content().debug().get());
+        assertFalse(Config.content().removeRecipe().get());
     }
 
     @Nested

--- a/src/test/scala/com/kotori316/fluidtank/BeforeAllTest.java
+++ b/src/test/scala/com/kotori316/fluidtank/BeforeAllTest.java
@@ -3,16 +3,17 @@ package com.kotori316.fluidtank;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.net.URL;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.electronwill.nightconfig.core.CommentedConfig;
 import cpw.mods.modlauncher.Launcher;
 import net.minecraft.SharedConstants;
 import net.minecraft.server.Bootstrap;
 import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
@@ -32,7 +33,6 @@ import net.minecraftforge.registries.GameData;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.junit.jupiter.api.BeforeAll;
-import scala.jdk.javaapi.CollectionConverters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -58,9 +58,7 @@ public abstract class BeforeAllTest {
             Bootstrap.bootStrap();
             GameData.unfreezeData();
             ModLoadingContext.get().setActiveContainer(new DummyModContainer());
-            Map<String, Object> map = new HashMap<>(CollectionConverters.asJava(Config.defaultConfig()));
-            map.put("debug", true);
-            Config.dummyContent_$eq(Utils.TestConfig.getTestInstance(map));
+            setConfig();
             mockCapability();
         }
     }
@@ -115,6 +113,16 @@ public abstract class BeforeAllTest {
         assertNotNull(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY);
         assertNotNull(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY);
         assertNotNull(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY);
+    }
+
+    private static void setConfig() {
+        var builder = new ForgeConfigSpec.Builder();
+        Config.sync(builder);
+        var config = builder.build();
+        var commentedConfig = CommentedConfig.inMemory();
+        config.correct(commentedConfig);
+        config.acceptConfig(commentedConfig);
+        Config.content().debug().set(true);
     }
 
     private static class DummyModContainer extends ModContainer {


### PR DESCRIPTION
Improve config by making it simple.

* Remove dummy config class to use in test.
  * Instead, use in-memory config in test.
* Use `enableWailaAndTOP`, which was not used in any places.
* Remove unused entry.